### PR TITLE
chore: use flexible rand version (0.8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.22", features = ["full"] }
 url = "2.3"
 warp = { version = "0.3", default-features = false }
 serde_json = "1.0"
-rand = "0.8.5"
+rand = "0.8"
 futures-util = "0.3"
 once_cell = "1.19"
 

--- a/pairing_api/Cargo.toml
+++ b/pairing_api/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.86"
 hex = "0.4.2"
 lazy_static = "1.4"
 paste = "1.0.15"
-rand = "0.8.5"
+rand = "0.8"
 regex = "1.7"
 relay_client = { path = "../relay_client" }
 relay_rpc = { path = "../relay_rpc" }

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.10"
 thiserror = "1.0"
-tokio = { version = "1.22", features = ["sync", "macros"] }
+tokio = { version = "1.22", features = ["rt", "sync", "macros"] }
 tokio-tungstenite-wasm = { git = "https://github.com/KomodoPlatform/tokio-tungstenite-wasm.git", features = ["rustls-tls-native-roots"], rev = "8fc7e2f" }
 tokio-util = "0.7"
 url = "2.3"

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 http = "1.0.0"
 pin-project = "1.0"
-rand = { version = "0.8.5", features = ["std", "small_rng"] }
+rand = { version = "0.8", features = ["std", "small_rng"] }
 relay_rpc = { path = "../relay_rpc" }
 reqwest = { version = "0.12.2", optional = true, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -31,7 +31,7 @@ jsonwebtoken = "8.1"
 k256 = { version = "0.13", optional = true }
 once_cell = "1.16"
 paste = "1.0.15"
-rand = "0.8.5"
+rand = "0.8"
 regex = "1.7"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-aux = { version = "4.1", default-features = false }


### PR DESCRIPTION
# Description
Updates the rand dependency to use a flexible version constraint (0.8) instead of a specific patch version
<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # (issue)

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
